### PR TITLE
Use easier installation instructions

### DIFF
--- a/README
+++ b/README
@@ -3,9 +3,8 @@ Includes code to draw on the LCD and read keys from the keyboard
 
 Installation:
 ------------
-Create a directory called SmartResponseXE in your ~/Documents/Arduino/libraries 
-directory and copy the cpp and h files there.
-It will be available as a library to import into your Arduino Sketch.
+1) Download the library: https://github.com/bitbank2/SmartResponseXE/archive/master.zip
+2) (In the Arduino IDE) Sketch > Include Library > Add .ZIP Library > select the downloaded file > Open
 
 Features:
 ---------


### PR DESCRIPTION
The previous instructions were unnecessarily complex and assumed a specific sketchbook location.