### PR TITLE
Fix undefined behavior in string write routine

### DIFF
--- a/SmartResponseXE.cpp
+++ b/SmartResponseXE.cpp
@@ -684,7 +684,8 @@ byte fgColor0, fgColor1, fgColor2, bgColor;
               bOut &= 0xe3; // clear middle 3 bits
               bOut |= fgColor1; // second pixel (3 bits)
            }
-           if (ucTemp[tx+2] & bMask && tx != 6)
+           if (tx != 6 &&
+               ucTemp[tx+2] & bMask)
            {
               bOut &= 0xfc; // clear lower 2 bits
               bOut |= fgColor2; // third pixel (2 bits)


### PR DESCRIPTION
The bounds check needs to happen prior to the array index, otherwise we will read off the end of the buffer.  In this version, the bounds check will fail, and the array indexing will not happen in that case, preventing a crash (access violation) I was seeing when I was using it.